### PR TITLE
Enhancement: using IntelliJ code formatter instead of indenting manually

### DIFF
--- a/src/main/kotlin/wu/seal/jsontokotlin/ConfigManager.kt
+++ b/src/main/kotlin/wu/seal/jsontokotlin/ConfigManager.kt
@@ -11,6 +11,7 @@ object ConfigManager : IConfigManager {
 
     private const val INDENT_KEY = "json-to-kotlin-class-indent-space-number"
     private const val ENABLE_MAP_TYP_KEY = "json-to-kotlin-class-enable-map-type"
+    private const val ENABLE_AUTO_REFORMAT = "json-to-kotlin-class-enable-auto-reformat"
 
     var indent: Int
         get() = if (TestConfig.isTestModel) TestConfig.indent else PropertiesComponent.getInstance().getInt(
@@ -30,5 +31,10 @@ object ConfigManager : IConfigManager {
             TestConfig.enableMapType = value
         } else PropertiesComponent.getInstance().setValue(ENABLE_MAP_TYP_KEY, value, false)
 
-
+    var enableAutoReformat: Boolean
+        get() = (TestConfig.isTestModel && TestConfig.enableAutoReformat)
+                || PropertiesComponent.getInstance().getBoolean(ENABLE_AUTO_REFORMAT, true)
+        set(value) = if(TestConfig.isTestModel) {
+            TestConfig.enableAutoReformat = value
+        } else PropertiesComponent.getInstance().setValue(ENABLE_AUTO_REFORMAT, value, true)
 }

--- a/src/main/kotlin/wu/seal/jsontokotlin/test/TestConfig.kt
+++ b/src/main/kotlin/wu/seal/jsontokotlin/test/TestConfig.kt
@@ -30,6 +30,7 @@ object TestConfig {
     var indent: Int = 4
 
     var enableMapType: Boolean = true
+    var enableAutoReformat: Boolean = true
 
     fun setToTestInitState() {
         isTestModel = true

--- a/src/main/kotlin/wu/seal/jsontokotlin/ui/SettingsOtherTab.kt
+++ b/src/main/kotlin/wu/seal/jsontokotlin/ui/SettingsOtherTab.kt
@@ -47,6 +47,11 @@ class SettingsOtherTab(layout: LayoutManager?, isDoubleBuffered: Boolean) : JPan
         enableMapType.isSelected = ConfigManager.enableMapType
         enableMapType.addActionListener { ConfigManager.enableMapType = enableMapType.isSelected }
 
+
+        val enableAutoReformat = JBCheckBox("Auto reformatting generated code according to code style. (Note that the Indent option bellow would be ignored.)")
+        enableAutoReformat.isSelected = ConfigManager.enableAutoReformat
+        enableAutoReformat.addActionListener { ConfigManager.enableAutoReformat = enableAutoReformat.isSelected }
+
         val indentJPanel = JPanel()
         indentJPanel.layout = FlowLayout(FlowLayout.LEFT)
         indentJPanel.add(JBLabel("Indent (number of space): "))
@@ -90,6 +95,10 @@ class SettingsOtherTab(layout: LayoutManager?, isDoubleBuffered: Boolean) : JPan
         add(Box.createVerticalStrut(JBUI.scale(20)))
 
         addComponentIntoVerticalBoxAlignmentLeft(enableMapType)
+
+        add(Box.createVerticalStrut(JBUI.scale(20)))
+
+        addComponentIntoVerticalBoxAlignmentLeft(enableAutoReformat)
 
         add(Box.createVerticalStrut(JBUI.scale(20)))
 

--- a/src/main/kotlin/wu/seal/jsontokotlin/utils/KotlinDataClassFileGenerator.kt
+++ b/src/main/kotlin/wu/seal/jsontokotlin/utils/KotlinDataClassFileGenerator.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiDirectory
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiFileFactory
+import wu.seal.jsontokotlin.ConfigManager
 import wu.seal.jsontokotlin.filetype.KotlinFileType
 import wu.seal.jsontokotlin.utils.classblockparse.ClassBlockStringParser
 import wu.seal.jsontokotlin.utils.classblockparse.KotlinDataClass
@@ -212,10 +213,12 @@ class KotlinDataClassFileGenerator {
 
             val fileAdded = directory.add(file)
 
-            var processor: AbstractLayoutCodeProcessor = ReformatCodeProcessor(project, fileAdded as PsiFile, null, false)
-            processor = OptimizeImportsProcessor(processor)
-            processor = RearrangeCodeProcessor(processor)
-            processor.run()
+            if (ConfigManager.enableAutoReformat) {
+                var processor: AbstractLayoutCodeProcessor = ReformatCodeProcessor(project, fileAdded as PsiFile, null, false)
+                processor = OptimizeImportsProcessor(processor)
+                processor = RearrangeCodeProcessor(processor)
+                processor.run()
+            }
         }
     }
 

--- a/src/main/kotlin/wu/seal/jsontokotlin/utils/KotlinDataClassFileGenerator.kt
+++ b/src/main/kotlin/wu/seal/jsontokotlin/utils/KotlinDataClassFileGenerator.kt
@@ -1,7 +1,12 @@
 package wu.seal.jsontokotlin.utils
 
+import com.intellij.codeInsight.actions.AbstractLayoutCodeProcessor
+import com.intellij.codeInsight.actions.OptimizeImportsProcessor
+import com.intellij.codeInsight.actions.RearrangeCodeProcessor
+import com.intellij.codeInsight.actions.ReformatCodeProcessor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiDirectory
+import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiFileFactory
 import wu.seal.jsontokotlin.filetype.KotlinFileType
 import wu.seal.jsontokotlin.utils.classblockparse.ClassBlockStringParser
@@ -204,7 +209,13 @@ class KotlinDataClassFileGenerator {
 
         executeCouldRollBackAction(project) {
             val file = psiFileFactory.createFileFromText("$fileName.kt", KotlinFileType(), kotlinFileContent)
-            directory.add(file)
+
+            val fileAdded = directory.add(file)
+
+            var processor: AbstractLayoutCodeProcessor = ReformatCodeProcessor(project, fileAdded as PsiFile, null, false)
+            processor = OptimizeImportsProcessor(processor)
+            processor = RearrangeCodeProcessor(processor)
+            processor.run()
         }
     }
 


### PR DESCRIPTION
In the current version of this plugin, indentations are manually inserted when generating Kotlin code, and a configuration item called "indent" is provided in the settings dialog.

However, I usually **reformat** the generated code and the "indent" configuration item seems useless, and I think it's normal that we want the generated code to meet the code style that we set in the "Preferences" in IntelliJ. So this PR just invoke the "Reformat" action (which existed as a built-in action in Intellij) and remove the "Indent" setting item. What do you think? @wuseal 