### PR TITLE
Initial support for `anyOf`

### DIFF
--- a/src/main/kotlin/wu/seal/jsontokotlin/JSON_SCHEMA_FORMAT_MAPPINGS.kt
+++ b/src/main/kotlin/wu/seal/jsontokotlin/JSON_SCHEMA_FORMAT_MAPPINGS.kt
@@ -1,6 +1,9 @@
 package wu.seal.jsontokotlin
 
 import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.OffsetDateTime
 
 /**
  * Created by Rody66 in 2019-04-18 3:16
@@ -10,9 +13,9 @@ import java.math.BigDecimal
 //https://json-schema.org/understanding-json-schema/reference/string.html#format
 //TODO this map should be moved to ConfigManager (UI)
 val JSON_SCHEMA_FORMAT_MAPPINGS = mapOf(
-    "date-time" to "org.threeten.bp.OffsetDateTime",
-    "date" to "org.threeten.bp.LocalDate",
-    "time" to "org.threeten.bp.LocalTime",
+    "date-time" to OffsetDateTime::class.java.canonicalName,
+    "date" to LocalDate::class.java.canonicalName,
+    "time" to LocalTime::class.java.canonicalName,
     "decimal" to BigDecimal::class.java.canonicalName
 
     //here can be another formats

--- a/src/main/kotlin/wu/seal/jsontokotlin/model/classscodestruct/EnumClass.kt
+++ b/src/main/kotlin/wu/seal/jsontokotlin/model/classscodestruct/EnumClass.kt
@@ -31,10 +31,19 @@ data class EnumClass(
     private fun generateValues(): List<String> {
         val list = mutableListOf<String>()
         for (i in enum.indices) {
-            val constantValue: Any = if (generic == KotlinClass.INT) (enum[i] as Double).toInt()
-            else enum[i].toString()
-            val constantName = xEnumNames?.get(i)
-                    ?: if (constantValue is Int) "_$constantValue" else constantValue.toString()
+            val constantValue: Any = when (generic) {
+                KotlinClass.INT -> (enum[i] as Double).toInt()
+                KotlinClass.DOUBLE -> enum[i] as Double
+                else -> enum[i].toString()
+            }
+            val extensionEnumName = xEnumNames?.get(i)
+            val constantName = when {
+                extensionEnumName != null -> extensionEnumName
+                constantValue is Int -> "_$constantValue"
+                // Not `.` allowed in variable names
+                constantValue is Double -> "_${constantValue.toInt()}"
+                else -> constantValue.toString()
+            }
             val finalValue = "${constantName}(${constToLiteral(constantValue)})" + if (i != enum.size - 1) "," else ";"
             list.add(finalValue)
         }

--- a/src/main/kotlin/wu/seal/jsontokotlin/model/classscodestruct/EnumClass.kt
+++ b/src/main/kotlin/wu/seal/jsontokotlin/model/classscodestruct/EnumClass.kt
@@ -1,5 +1,6 @@
 package wu.seal.jsontokotlin.model.classscodestruct
 
+import wu.seal.jsontokotlin.utils.constToLiteral
 import wu.seal.jsontokotlin.utils.getIndent
 import wu.seal.jsontokotlin.utils.toAnnotationComments
 import java.lang.StringBuilder
@@ -34,7 +35,7 @@ data class EnumClass(
             else enum[i].toString()
             val constantName = xEnumNames?.get(i)
                     ?: if (constantValue is Int) "_$constantValue" else constantValue.toString()
-            val finalValue = "${constantName}(${constantValue})" + if (i != enum.size - 1) "," else ";"
+            val finalValue = "${constantName}(${constToLiteral(constantValue)})" + if (i != enum.size - 1) "," else ";"
             list.add(finalValue)
         }
         return list

--- a/src/main/kotlin/wu/seal/jsontokotlin/model/classscodestruct/Property.kt
+++ b/src/main/kotlin/wu/seal/jsontokotlin/model/classscodestruct/Property.kt
@@ -31,4 +31,10 @@ data class Property(
             }
         }
     }
+
+    fun inheritanceCode(): String {
+        return buildString {
+            append(name).append(" = ").append(value)
+        }
+    }
 }

--- a/src/main/kotlin/wu/seal/jsontokotlin/model/classscodestruct/SealedClass.kt
+++ b/src/main/kotlin/wu/seal/jsontokotlin/model/classscodestruct/SealedClass.kt
@@ -1,0 +1,60 @@
+package wu.seal.jsontokotlin.model.classscodestruct
+
+import wu.seal.jsontokotlin.utils.getIndent
+import wu.seal.jsontokotlin.utils.toAnnotationComments
+import wu.seal.jsontokotlin.utils.addIndent
+
+data class SealedClass(
+    override val name: String,
+    override val generic: KotlinClass,
+    override val referencedClasses: List<KotlinClass> = listOf(generic),
+    val discriminatoryProperties: List<Property>,
+    val comments: String = "",
+    override val modifiable: Boolean = true
+) : ModifiableKotlinClass, NoGenericKotlinClass {
+
+    override fun rename(newName: String): KotlinClass = copy(name = newName)
+    override fun getCode(): String {
+        return getOnlyCurrentCode()
+    }
+
+    private fun getDiscriminatoryPropertiesCode(): String {
+        return discriminatoryPropertiesCode(this.discriminatoryProperties)
+    }
+
+    override fun getOnlyCurrentCode(): String {
+        val indent = getIndent()
+        val innerReferencedClasses =
+            referencedClasses.flatMap { it.referencedClasses }.distinctBy { it.name }
+                .filter { it.modifiable }
+
+        return buildString {
+            append(comments.toAnnotationComments())
+            append("sealed class $name(${getDiscriminatoryPropertiesCode()}) {\n")
+            referencedClasses.forEach { it ->
+                // TODO: Ensure that `referencedClasses` are actually of type `DataClass`
+                append((it as DataClass).withExtends(
+                    discriminatoryProperties.map { it.name },
+                    this@SealedClass).getOnlyCurrentCode().addIndent(indent))
+                append("\n")
+            }
+            append("}\n\n")
+            innerReferencedClasses.forEach {
+                append(it.getCode())
+                append("\n")
+            }
+        }
+    }
+
+    override fun replaceReferencedClasses(replaceRule: Map<KotlinClass, KotlinClass>): KotlinClass {
+        TODO("Not yet implemented")
+    }
+
+    companion object {
+        fun discriminatoryPropertiesCode(properties: List<Property>): String {
+            return properties.joinToString(", ") {
+                it.getCode()
+            }
+        }
+    }
+}

--- a/src/main/kotlin/wu/seal/jsontokotlin/model/jsonschema/PropertyDef.kt
+++ b/src/main/kotlin/wu/seal/jsontokotlin/model/jsonschema/PropertyDef.kt
@@ -1,6 +1,7 @@
 package wu.seal.jsontokotlin.model.jsonschema
 
 import com.google.gson.annotations.SerializedName
+import wu.seal.jsontokotlin.model.classscodestruct.KotlinClass
 
 class PropertyDef(
         type: Any? = null,
@@ -13,6 +14,7 @@ class PropertyDef(
         val format: String? = null,
 
         val enum: Array<Any>? = null,
+        val const: Any? = null,
 
     //NJsonSchema:
         @SerializedName("x-enumNames")

--- a/src/main/kotlin/wu/seal/jsontokotlin/utils/TypeHelper.kt
+++ b/src/main/kotlin/wu/seal/jsontokotlin/utils/TypeHelper.kt
@@ -223,3 +223,15 @@ fun getMapValueTypeConvertFromJsonObject(jsonObject: JsonObject): String {
 fun getNonNullPrimitiveType(rawType: String): String {
     return if (rawType in NULLABLE_PRIMITIVE_TYPES) rawType.replace("?", "") else rawType
 }
+
+fun constToLiteral(value: Any): String? {
+    return when (value) {
+        is String -> "\"${value}\""
+        is Byte -> "$value"
+        is Short -> "$value"
+        is Int -> "$value"
+        is Long -> "$value"
+        is Double -> "$value"
+        else -> null
+    }
+}

--- a/src/test/kotlin/wu/seal/jsontokotlin/EnumTest.kt
+++ b/src/test/kotlin/wu/seal/jsontokotlin/EnumTest.kt
@@ -1,0 +1,65 @@
+package wu.seal.jsontokotlin
+
+import com.winterbe.expekt.should
+import org.junit.Before
+import org.junit.Test
+import wu.seal.jsontokotlin.test.TestConfig
+
+class EnumTest {
+    @Before
+    fun setUp() {
+        TestConfig.setToTestInitStateForJsonSchema()
+    }
+
+    @Test
+    fun testNumericEnum() {
+        val json = """{
+            "${"$"}ref": "#/definitions/Container",
+            "${"$"}schema": "http://json-schema.org/draft-07/schema#",
+            "definitions": {
+                "Container": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "score": {
+                            "${"$"}ref": "#/definitions/Score"
+                        }
+                    },
+                    "required": [
+                        "score"
+                    ],
+                    "type": "object"                
+                },
+                "Score": {
+                    "enum": [
+                        1,
+                        2,
+                        3,
+                        4
+                    ],
+                    "type": "number"
+                }
+            }
+        }""".trimIndent()
+
+        val expected = """   
+                   
+data class Test(
+    val score: Score
+) {
+    enum class Score(val value: Double) {
+        _1(1.0),
+
+        _2(2.0),
+
+        _3(3.0),
+
+        _4(4.0);
+    }
+}
+""".trim()
+
+        val result = json.generateKotlinClass("Test").getCode()
+        result.trim().should.be.equal(expected)
+
+    }
+}

--- a/src/test/kotlin/wu/seal/jsontokotlin/JsonSchemaGeneratorTest.kt
+++ b/src/test/kotlin/wu/seal/jsontokotlin/JsonSchemaGeneratorTest.kt
@@ -323,7 +323,7 @@ data class veggie(
 
         val expected = """data class LogEntry(
     val id: String?,
-    val timestamp: org.threeten.bp.OffsetDateTime,
+    val timestamp: java.time.OffsetDateTime,
     val removed: Boolean,
     /**
      * Тип события

--- a/src/test/kotlin/wu/seal/jsontokotlin/UnionTypeTest.kt
+++ b/src/test/kotlin/wu/seal/jsontokotlin/UnionTypeTest.kt
@@ -1,0 +1,112 @@
+package wu.seal.jsontokotlin
+
+import com.winterbe.expekt.should
+import org.junit.Before
+import org.junit.Test
+import wu.seal.jsontokotlin.test.TestConfig
+
+class UnionTypeTest {
+    @Before
+    fun setUp() {
+        TestConfig.setToTestInitStateForJsonSchema()
+    }
+
+    @Test
+    fun testUnionType() {
+        // TODO: Top-level union types don't work yet
+        val json = """
+            {
+  "${"$"}ref": "#/definitions/Container",
+  "${"$"}schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "A": {
+      "additionalProperties": false,
+      "properties": {
+        "baseMember": {
+          "type": "string"
+        },
+        "childMember": {
+          "type": "number"
+        },
+        "type": {
+          "const": 0,
+          "type": "number"
+        }
+      },
+      "required": [
+        "baseMember",
+        "childMember",
+        "type"
+      ],
+      "type": "object"
+    },
+    "B": {
+      "additionalProperties": false,
+      "properties": {
+        "baseMember": {
+          "type": "string"
+        },
+        "childMember": {
+          "type": "string"
+        },
+        "type": {
+          "const": 1,
+          "type": "number"
+        }
+      },
+      "required": [
+        "baseMember",
+        "childMember",
+        "type"
+      ],
+      "type": "object"
+    },
+    "Container": {
+      "additionalProperties": false,
+      "properties": {
+        "union": {
+          "${"$"}ref": "#/definitions/Union"
+        }
+      },
+      "required": [
+        "union"
+      ],
+      "type": "object"
+    },
+    "Union": {
+      "anyOf": [
+        {
+          "${"$"}ref": "#/definitions/A"
+        },
+        {
+          "${"$"}ref": "#/definitions/B"
+        }
+      ]
+    }
+  }
+}
+        """.trimIndent()
+
+        val expected = """
+data class Test(
+    val union: Union
+) {
+    sealed class Union(val type: Double) {
+        data class A(
+            val baseMember: String,
+            val childMember: Double,
+        ) : Union(type = 0.0)
+        data class B(
+            val baseMember: String,
+            val childMember: String,
+        ) : Union(type = 1.0)
+    }
+
+
+}            
+        """.trim()
+
+        val result = json.generateKotlinClass("Test").getCode()
+        result.trim().should.be.equal(expected)
+    }
+}


### PR DESCRIPTION
Initial support for non-top-level union types (with discriminatory fields). 
It works well enough for my use-case in its current state, but there are still some rough edges:
* Types referenced in `anyOf` have to resolve to `DataClass`es, otherwise unexpected behaviour occurs
* Top-level union types don't work
* [`replaceReferencedClasses`](https://github.com/wuseal/JsonToKotlinClass/blob/b5496b6a13dcf2638fc8d67784787f31f3839b30/src/main/kotlin/wu/seal/jsontokotlin/model/classscodestruct/KotlinClass.kt#L52) isn't yet implemented for `SealClass`es

<details>
<summary>Example</summary>

```json
{
  "$ref": "#/definitions/Container",
  "$schema": "http://json-schema.org/draft-07/schema#",
  "definitions": {
    "A": {
      "additionalProperties": false,
      "properties": {
        "baseMember": {
          "type": "string"
        },
        "childMember": {
          "type": "number"
        },
        "type": {
          "const": 0,
          "type": "number"
        }
      },
      "required": [
        "baseMember",
        "childMember",
        "type"
      ],
      "type": "object"
    },
    "B": {
      "additionalProperties": false,
      "properties": {
        "baseMember": {
          "type": "string"
        },
        "childMember": {
          "type": "string"
        },
        "type": {
          "const": 1,
          "type": "number"
        }
      },
      "required": [
        "baseMember",
        "childMember",
        "type"
      ],
      "type": "object"
    },
    "Container": {
      "additionalProperties": false,
      "properties": {
        "union": {
          "$ref": "#/definitions/Union"
        }
      },
      "required": [
        "union"
      ],
      "type": "object"
    },
    "Union": {
      "anyOf": [
        {
          "$ref": "#/definitions/A"
        },
        {
          "$ref": "#/definitions/B"
        }
      ]
    }
  }
}
```

<p align="center">— ↓ —</p>

```kotlin
data class Test(
    val union: Union
) {
    sealed class Union(val type: Double) {
        data class A(
            val baseMember: String,
            val childMember: Double,
        ) : Union(type = 0.0)
        data class B(
            val baseMember: String,
            val childMember: String,
        ) : Union(type = 1.0)
    }
}  
```
</details>

I tried to be as non-invasive as possible, but some opinionated changes did slip into this PR (like [switching to the built-in time classes](https://github.com/wuseal/JsonToKotlinClass/commit/c9a2fbf3f7318c3295c533d226e799c1a42cceb7)).