### PR TITLE
optimize code builder & bugfix: when enable [Replace constructor parameters by member variables], the annotation not go to next line.

### DIFF
--- a/src/main/kotlin/extensions/nstd/DataClassCodeBuilderForNoConstructorMemberFields.kt
+++ b/src/main/kotlin/extensions/nstd/DataClassCodeBuilderForNoConstructorMemberFields.kt
@@ -1,5 +1,6 @@
 package extensions.nstd
 
+import extensions.wu.seal.BaseDataClassCodeBuilder
 import wu.seal.jsontokotlin.model.builder.IKotlinDataClassCodeBuilder
 import wu.seal.jsontokotlin.model.classscodestruct.DataClass
 import wu.seal.jsontokotlin.utils.addIndent
@@ -12,7 +13,7 @@ import wu.seal.jsontokotlin.utils.toAnnotationComments
  * Created by Nstd on 2020/6/29 15:40.
  */
 class DataClassCodeBuilderForNoConstructorMemberFields(private val kotlinDataClassCodeBuilder: IKotlinDataClassCodeBuilder) :
-    IKotlinDataClassCodeBuilder {
+        BaseDataClassCodeBuilder(kotlinDataClassCodeBuilder) {
 
     override fun DataClass.genBody(): String {
         val delegateBody = kotlinDataClassCodeBuilder.run { genBody() }
@@ -27,22 +28,6 @@ class DataClassCodeBuilderForNoConstructorMemberFields(private val kotlinDataCla
         }
     }
 
-    override fun DataClass.genClassComment(): String {
-        return kotlinDataClassCodeBuilder.run { genClassComment() }
-    }
-
-    override fun DataClass.genClassAnnotations(): String {
-        return kotlinDataClassCodeBuilder.run { genClassAnnotations() }
-    }
-
-    override fun DataClass.genClassName(): String {
-        return kotlinDataClassCodeBuilder.run { genClassName() }
-    }
-
-
-    override fun DataClass.genParentClass(): String {
-        return kotlinDataClassCodeBuilder.run { genParentClass() }
-    }
 
     override fun DataClass.genPrimaryConstructorProperties(): String {
         return ""
@@ -58,6 +43,7 @@ class DataClassCodeBuilderForNoConstructorMemberFields(private val kotlinDataCla
                 }
                 append(addIndentCode)
                 if (!fromJsonSchema && commentCode.isNotBlank()) append(" // ").append(commentCode)
+                if (index != properties.size - 1) append("\n")
             }
         }
     }

--- a/src/main/kotlin/extensions/wu/seal/BaseDataClassCodeBuilder.kt
+++ b/src/main/kotlin/extensions/wu/seal/BaseDataClassCodeBuilder.kt
@@ -2,14 +2,46 @@ package extensions.wu.seal
 
 import wu.seal.jsontokotlin.model.builder.IKotlinDataClassCodeBuilder
 import wu.seal.jsontokotlin.model.classscodestruct.DataClass
+import wu.seal.jsontokotlin.model.classscodestruct.KotlinClass
 
 /**
  * Created by Nstd on 2021/8/6 11:17.
  */
-abstract class BaseDataClassCodeBuilder(private val kotlinDataClassCodeBuilder: IKotlinDataClassCodeBuilder)
-    : IKotlinDataClassCodeBuilder by kotlinDataClassCodeBuilder {
+abstract class BaseDataClassCodeBuilder(private val kotlinDataClassCodeBuilder: IKotlinDataClassCodeBuilder) :
+    IKotlinDataClassCodeBuilder by kotlinDataClassCodeBuilder {
 
-    override fun genPrimaryConstructor(clazz: DataClass): String = super.genPrimaryConstructor(clazz)
-    override fun getCode(clazz: DataClass): String = super.getCode(clazz)
-    override fun getOnlyCurrentCode(clazz: DataClass): String = super.getOnlyCurrentCode(clazz)
+    open fun DataClass.genPrimaryConstructor(): String {
+        return buildString {
+            val primaryConstructorPropertiesCode = genPrimaryConstructorProperties()
+            if (primaryConstructorPropertiesCode.isNotBlank()) {
+                append("(").append("\n")
+                append(primaryConstructorPropertiesCode)
+                append(")")
+            }
+        }
+    }
+
+    final override fun getCode(clazz: DataClass): String {
+        clazz.run {
+            return buildString {
+                genClassComment().executeWhenNotBlank { append(it) }
+                genClassAnnotations().executeWhenNotBlank { appendLine(it) }
+                append(genClassName())
+                genPrimaryConstructor().executeWhenNotBlank { append(it) }
+                genParentClass().executeWhenNotBlank { append(" $it") }
+                genBody().executeWhenNotBlank {
+                    appendLine(" {")
+                    appendLine(it)
+                    append("}")
+                }
+            }
+        }
+    }
+
+    final override fun getOnlyCurrentCode(clazz: DataClass): String {
+        clazz.run {
+            val newProperties = properties.map { it.copy(typeObject = KotlinClass.ANY) }
+            return copy(properties = newProperties).getCode()
+        }
+    }
 }

--- a/src/main/kotlin/extensions/wu/seal/BaseDataClassCodeBuilder.kt
+++ b/src/main/kotlin/extensions/wu/seal/BaseDataClassCodeBuilder.kt
@@ -1,0 +1,15 @@
+package extensions.wu.seal
+
+import wu.seal.jsontokotlin.model.builder.IKotlinDataClassCodeBuilder
+import wu.seal.jsontokotlin.model.classscodestruct.DataClass
+
+/**
+ * Created by Nstd on 2021/8/6 11:17.
+ */
+abstract class BaseDataClassCodeBuilder(private val kotlinDataClassCodeBuilder: IKotlinDataClassCodeBuilder)
+    : IKotlinDataClassCodeBuilder by kotlinDataClassCodeBuilder {
+
+    override fun genPrimaryConstructor(clazz: DataClass): String = super.genPrimaryConstructor(clazz)
+    override fun getCode(clazz: DataClass): String = super.getCode(clazz)
+    override fun getOnlyCurrentCode(clazz: DataClass): String = super.getOnlyCurrentCode(clazz)
+}

--- a/src/main/kotlin/extensions/wu/seal/DataClassCodeBuilderDisableDataClass.kt
+++ b/src/main/kotlin/extensions/wu/seal/DataClassCodeBuilderDisableDataClass.kt
@@ -9,29 +9,10 @@ import wu.seal.jsontokotlin.model.classscodestruct.DataClass
  * Created by Seal on 2020/7/7 21:40.
  */
 class DataClassCodeBuilderDisableDataClass(private val kotlinDataClassCodeBuilder: IKotlinDataClassCodeBuilder) :
-    IKotlinDataClassCodeBuilder {
-    override fun DataClass.genClassComment(): String {
-        return kotlinDataClassCodeBuilder.run { genClassComment() }
-    }
-
-    override fun DataClass.genClassAnnotations(): String {
-        return kotlinDataClassCodeBuilder.run { genClassAnnotations() }
-    }
+    BaseDataClassCodeBuilder(kotlinDataClassCodeBuilder) {
 
     override fun DataClass.genClassName(): String {
         val originClassName = kotlinDataClassCodeBuilder.run { genClassName() }
         return originClassName.replace("data ", "")
-    }
-
-    override fun DataClass.genParentClass(): String {
-        return kotlinDataClassCodeBuilder.run { genParentClass() }
-    }
-
-    override fun DataClass.genBody(): String {
-        return kotlinDataClassCodeBuilder.run { genBody() }
-    }
-
-    override fun DataClass.genPrimaryConstructorProperties(): String {
-        return kotlinDataClassCodeBuilder.run { genPrimaryConstructorProperties() }
     }
 }

--- a/src/main/kotlin/extensions/wu/seal/DataClassCodeBuilderForInternalClass.kt
+++ b/src/main/kotlin/extensions/wu/seal/DataClassCodeBuilderForInternalClass.kt
@@ -9,29 +9,10 @@ import wu.seal.jsontokotlin.model.classscodestruct.DataClass
  * Created by Seal on 2020/7/7 21:40.
  */
 class DataClassCodeBuilderForInternalClass(private val kotlinDataClassCodeBuilder: IKotlinDataClassCodeBuilder) :
-    IKotlinDataClassCodeBuilder {
+    BaseDataClassCodeBuilder(kotlinDataClassCodeBuilder) {
 
     override fun DataClass.genClassName(): String {
         val originClassName = kotlinDataClassCodeBuilder.run { genClassName() }
         return "internal $originClassName"
-    }
-    override fun DataClass.genClassComment(): String {
-        return kotlinDataClassCodeBuilder.run { genClassComment() }
-    }
-
-    override fun DataClass.genClassAnnotations(): String {
-        return kotlinDataClassCodeBuilder.run { genClassAnnotations() }
-    }
-
-    override fun DataClass.genParentClass(): String {
-        return kotlinDataClassCodeBuilder.run { genParentClass() }
-    }
-
-    override fun DataClass.genBody(): String {
-        return kotlinDataClassCodeBuilder.run { genBody() }
-    }
-
-    override fun DataClass.genPrimaryConstructorProperties(): String {
-        return kotlinDataClassCodeBuilder.run { genPrimaryConstructorProperties() }
     }
 }

--- a/src/main/kotlin/extensions/yuan/varenyzc/DataClassCodeBuilderForAddingBuildFromJsonObject.kt
+++ b/src/main/kotlin/extensions/yuan/varenyzc/DataClassCodeBuilderForAddingBuildFromJsonObject.kt
@@ -1,5 +1,6 @@
 package extensions.yuan.varenyzc
 
+import extensions.wu.seal.BaseDataClassCodeBuilder
 import wu.seal.jsontokotlin.model.builder.IKotlinDataClassCodeBuilder
 import wu.seal.jsontokotlin.model.classscodestruct.DataClass
 import wu.seal.jsontokotlin.utils.newLine
@@ -11,7 +12,7 @@ import wu.seal.jsontokotlin.utils.times
  * Created by Seal on 2020/7/7 21:45.
  */
 class DataClassCodeBuilderForAddingBuildFromJsonObject(private val kotlinDataClassCodeBuilder: IKotlinDataClassCodeBuilder) :
-    IKotlinDataClassCodeBuilder {
+        BaseDataClassCodeBuilder(kotlinDataClassCodeBuilder) {
 
     private val baseTypeList = listOf<String>("Int", "String", "Boolean", "Double", "Float", "Long")
 
@@ -52,12 +53,12 @@ class DataClassCodeBuilderForAddingBuildFromJsonObject(private val kotlinDataCla
                     }
                     else -> {
                         append(indent * 5).append(
-                            "${
-                                property.type.replace(
-                                    "?",
-                                    ""
-                                )
-                            }.buildFromJson(optJSONObject(\"${property.originName}\"))"
+                                "${
+                                    property.type.replace(
+                                            "?",
+                                            ""
+                                    )
+                                }.buildFromJson(optJSONObject(\"${property.originName}\"))"
                         )
                     }
                 }
@@ -73,25 +74,5 @@ class DataClassCodeBuilderForAddingBuildFromJsonObject(private val kotlinDataCla
             append(indent * 2).append("}").newLine()
             append(indent * 1).append("}")
         }
-    }
-
-    override fun DataClass.genClassName(): String {
-        return  kotlinDataClassCodeBuilder.run { genClassName() }
-    }
-
-    override fun DataClass.genClassComment(): String {
-        return kotlinDataClassCodeBuilder.run { genClassComment() }
-    }
-
-    override fun DataClass.genClassAnnotations(): String {
-        return kotlinDataClassCodeBuilder.run { genClassAnnotations() }
-    }
-
-    override fun DataClass.genParentClass(): String {
-        return kotlinDataClassCodeBuilder.run { genParentClass() }
-    }
-
-    override fun DataClass.genPrimaryConstructorProperties(): String {
-        return kotlinDataClassCodeBuilder.run { genPrimaryConstructorProperties() }
     }
 }

--- a/src/main/kotlin/wu/seal/jsontokotlin/model/builder/IKotlinDataClassCodeBuilder.kt
+++ b/src/main/kotlin/wu/seal/jsontokotlin/model/builder/IKotlinDataClassCodeBuilder.kt
@@ -11,13 +11,15 @@ interface IKotlinDataClassCodeBuilder : ICodeBuilder<DataClass> {
     fun DataClass.genBody(): String
     fun DataClass.genPrimaryConstructorProperties(): String
 
-    fun DataClass.genPrimaryConstructor(): String {
-        return buildString {
-            val primaryConstructorPropertiesCode = genPrimaryConstructorProperties()
-            if (primaryConstructorPropertiesCode.isNotBlank()) {
-                append("(").append("\n")
-                append(primaryConstructorPropertiesCode)
-                append(")")
+    fun genPrimaryConstructor(clazz: DataClass): String {
+        return clazz.run {
+            buildString {
+                val primaryConstructorPropertiesCode = genPrimaryConstructorProperties()
+                if (primaryConstructorPropertiesCode.isNotBlank()) {
+                    append("(").append("\n")
+                    append(primaryConstructorPropertiesCode)
+                    append(")")
+                }
             }
         }
     }
@@ -28,7 +30,7 @@ interface IKotlinDataClassCodeBuilder : ICodeBuilder<DataClass> {
                 genClassComment().executeWhenNotBlank { append(it) }
                 genClassAnnotations().executeWhenNotBlank { appendLine(it) }
                 append(genClassName())
-                genPrimaryConstructor().executeWhenNotBlank { append(it) }
+                genPrimaryConstructor(this@run).executeWhenNotBlank { append(it) }
                 genParentClass().executeWhenNotBlank { append(" $it") }
                 genBody().executeWhenNotBlank {
                     appendLine(" {")

--- a/src/main/kotlin/wu/seal/jsontokotlin/model/builder/IKotlinDataClassCodeBuilder.kt
+++ b/src/main/kotlin/wu/seal/jsontokotlin/model/builder/IKotlinDataClassCodeBuilder.kt
@@ -1,7 +1,6 @@
 package wu.seal.jsontokotlin.model.builder
 
 import wu.seal.jsontokotlin.model.classscodestruct.DataClass
-import wu.seal.jsontokotlin.model.classscodestruct.KotlinClass
 
 interface IKotlinDataClassCodeBuilder : ICodeBuilder<DataClass> {
     fun DataClass.genClassComment(): String
@@ -10,44 +9,39 @@ interface IKotlinDataClassCodeBuilder : ICodeBuilder<DataClass> {
     fun DataClass.genParentClass(): String
     fun DataClass.genBody(): String
     fun DataClass.genPrimaryConstructorProperties(): String
-
-    fun genPrimaryConstructor(clazz: DataClass): String {
-        return clazz.run {
-            buildString {
-                val primaryConstructorPropertiesCode = genPrimaryConstructorProperties()
-                if (primaryConstructorPropertiesCode.isNotBlank()) {
-                    append("(").append("\n")
-                    append(primaryConstructorPropertiesCode)
-                    append(")")
-                }
-            }
-        }
-    }
-
-    override fun getCode(clazz: DataClass): String {
-        clazz.run {
-            return buildString {
-                genClassComment().executeWhenNotBlank { append(it) }
-                genClassAnnotations().executeWhenNotBlank { appendLine(it) }
-                append(genClassName())
-                genPrimaryConstructor(this@run).executeWhenNotBlank { append(it) }
-                genParentClass().executeWhenNotBlank { append(" $it") }
-                genBody().executeWhenNotBlank {
-                    appendLine(" {")
-                    appendLine(it)
-                    append("}")
-                }
-            }
-        }
-    }
-
-    override fun getOnlyCurrentCode(clazz: DataClass): String {
-        clazz.run {
-            val newProperties = properties.map { it.copy(typeObject = KotlinClass.ANY) }
-            return copy(properties = newProperties).getCode()
-        }
-    }
-
     fun String.executeWhenNotBlank(call: (String) -> Unit) = if (isNotBlank()) call(this) else Unit
 
+    object EmptyImpl: IKotlinDataClassCodeBuilder {
+        override fun getCode(clazz: DataClass): String {
+            return ""
+        }
+
+        override fun getOnlyCurrentCode(clazz: DataClass): String {
+            return ""
+        }
+
+        override fun DataClass.genClassComment(): String {
+            return ""
+        }
+
+        override fun DataClass.genClassAnnotations(): String {
+            return ""
+        }
+
+        override fun DataClass.genClassName(): String {
+            return ""
+        }
+
+        override fun DataClass.genParentClass(): String {
+            return ""
+        }
+
+        override fun DataClass.genBody(): String {
+            return ""
+        }
+
+        override fun DataClass.genPrimaryConstructorProperties(): String {
+            return ""
+        }
+    }
 }

--- a/src/main/kotlin/wu/seal/jsontokotlin/model/builder/KotlinDataClassCodeBuilder.kt
+++ b/src/main/kotlin/wu/seal/jsontokotlin/model/builder/KotlinDataClassCodeBuilder.kt
@@ -1,5 +1,6 @@
 package wu.seal.jsontokotlin.model.builder
 
+import extensions.wu.seal.BaseDataClassCodeBuilder
 import wu.seal.jsontokotlin.model.classscodestruct.*
 import wu.seal.jsontokotlin.utils.*
 
@@ -8,7 +9,7 @@ import wu.seal.jsontokotlin.utils.*
  *
  * Created by Nstd on 2020/6/29 15:40.
  */
-object KotlinDataClassCodeBuilder : IKotlinDataClassCodeBuilder {
+object KotlinDataClassCodeBuilder : BaseDataClassCodeBuilder(IKotlinDataClassCodeBuilder.EmptyImpl) {
 
     override fun DataClass.genClassComment(): String {
         return buildString {

--- a/src/test/kotlin/extensions/nstd/ReplaceConstructorParametersByMemberVariablesSupportTest.kt
+++ b/src/test/kotlin/extensions/nstd/ReplaceConstructorParametersByMemberVariablesSupportTest.kt
@@ -11,10 +11,11 @@ import wu.seal.jsontokotlin.test.TestConfig
  * Created by Nstd on 2020/6/29 17:53.
  */
 class ReplaceConstructorParametersByMemberVariablesSupportTest {
-    private val json = """{"a":1}"""
+    private val json = """{"a":1,"b":2}"""
     private val expectCode: String = """
         data class Output {
             val a: Int // 1
+            val b: Int // 2
         }
     """.trimIndent()
 
@@ -27,5 +28,5 @@ class ReplaceConstructorParametersByMemberVariablesSupportTest {
     fun intercept() {
         ReplaceConstructorParametersByMemberVariablesSupport.getTestHelper().setConfig(ReplaceConstructorParametersByMemberVariablesSupport.configKey, true.toString())
         json.generateKotlinClass("Output").applyInterceptor(ReplaceConstructorParametersByMemberVariablesSupport).getCode().should.be.equal(expectCode)
-     }
+    }
 }


### PR DESCRIPTION
1. delegate code builder interface, make it easier to be implemented.
2. bugfix: when enable [Replace constructor parameters by member variables], the annotation not go to next line.