### PR TITLE
Migrate jsontokotlin library from JCenter to MavenCentral

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Hi, Welcome! This is a plugin to generate Kotlin `data class` from JSON string, 
 We also have a `Java/Kotlin` [library](doc/LIBRARY.md). With this you can generate Kotlin `data class` from JSON string **programmatically**. 
 
 ```groovy
-implementation 'wu.seal.jsontokotlin:library:3.6.1'
+implementation 'com.sealwu.jsontokotlin:library:3.6.1'
 ```
 
 ### Overview

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,12 +1,11 @@
 # Change Log
 
-## [3.7.4\-eap](https://github.com/wuseal/JsonToKotlinClass/tree/3.7.4-eap) (2022-05-22)
-[View commits](https://github.com/wuseal/JsonToKotlinClass/compare/3.7.3...3.7.4-eap)
+## [3.7.4](https://github.com/wuseal/JsonToKotlinClass/tree/3.7.4) (2022-05-22)
+[View commits](https://github.com/wuseal/JsonToKotlinClass/compare/3.7.3...3.7.4)
 
 **Bugfix**
 
 - Write\-access exception [\#308](https://github.com/wuseal/JsonToKotlinClass/issues/308)
-- JSONSchema生成类失败 [\#392](https://github.com/wuseal/JsonToKotlinClass/issues/392)
 - Nullable Types and Non Nullable Default Value Strategy [\#391](https://github.com/wuseal/JsonToKotlinClass/issues/391)
 - Repeating classes instead of making a relation between them\! [\#381](https://github.com/wuseal/JsonToKotlinClass/issues/381)
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'org.jetbrains.kotlin.jvm' version '1.3.72'
     id 'maven'
     id 'maven-publish'
-    id 'com.jfrog.bintray' version '1.8.5'
+    id 'signing'
 }
 
 repositories {
@@ -71,9 +71,9 @@ def pomConfig = {
     }
     developers {
         developer {
-            id "shifarshifz"
-            name "shifarshifz"
-            email "theapache64@gmail.com"
+            id "wuseal"
+            name "wuseal"
+            email "wusealking@gmail.com"
         }
     }
 
@@ -93,7 +93,7 @@ publishing {
             artifact javadocJar {
                 classifier "javadoc"
             }
-            groupId 'wu.seal.jsontokotlin'
+            groupId 'com.sealwu.jsontokotlin'
             artifactId 'library'
             version "$versions.j2k_version"
             pom.withXml {
@@ -105,24 +105,17 @@ publishing {
             }
         }
     }
-}
-
-bintray {
-    user = System.getenv('BINTRAY_USER')
-    key = System.getenv('BINTRAY_API_KEY')
-    publications = ['mavenPublication']
-
-    pkg {
-        repo = 'maven'
-        name = 'JsonToKotlinClass'
-        userOrg = 'shifarshifz'
-        licenses = ['GPL-3.0']
-        vcsUrl = 'https://github.com/wuseal/JsonToKotlinClass.git'
-        version {
-            name = versions.j2k_version
-            desc = versions.j2k_version
-            released = new Date()
+    repositories {
+        maven {
+            name 'mavenCentral'
+            // change URLs to point to your repos, e.g. http://my.org/repo
+            def snapshotsRepoUrl = 'https://s01.oss.sonatype.org/content/repositories/snapshots/'
+            def releasesRepoUrl = 'https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/'
+            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
+            credentials(PasswordCredentials)
         }
     }
-
+}
+signing {
+    sign publishing.publications.mavenPublication
 }


### PR DESCRIPTION
The new library address is 
`com.sealwu.jsontokotlin:library:3.6.1`

