### PR TITLE
Fix Spelling Error in Library documentation

### DIFF
--- a/doc/LIBRARY.md
+++ b/doc/LIBRARY.md
@@ -29,7 +29,7 @@ val actualOutput = JsonToKotlinBuilder()
     .enableComments(true) // optional, default : false
     .enableOrderByAlphabetic(true) // optional : default : false
     .enableInnerClassModel(true) // optional, default : false
-    .enabelMapType(true)// optional, default : false
+    .enableMapType(true)// optional, default : false
     .enableCreateAnnotationOnlyWhenNeeded(true) // optional, default : false
     .setIndent(4)// optional, default : 4
     .setParentClassTemplate("android.os.Parcelable") // optional, default : ""


### PR DESCRIPTION
Just found this library and it looks like exactly what I need. Thanks for building it. I copy & pasted the block from the library documentation and found a small spelling error.